### PR TITLE
Throw error on connection close

### DIFF
--- a/lib/subscribe.js
+++ b/lib/subscribe.js
@@ -6,6 +6,10 @@ module.exports = function Subscribe(url, opts) {
     Channel(url, opts, function (err, ch, conn) {
       if (err) throw err;
 
+      conn.on('close', function (err) {
+        if (err) throw err;
+      });
+
       ch.assertExchange(ex, 'fanout', { durable: false });
       ch.assertQueue('', { exclusive: true }, function (err, queue) {
         if (err) throw err;


### PR DESCRIPTION
Throw an error in subscribe method when AMQP connection is closed.
